### PR TITLE
fix get_file in Blacklist.pm

### DIFF
--- a/payload/lib/EdgeOS/DNS/Blacklist.pm
+++ b/payload/lib/EdgeOS/DNS/Blacklist.pm
@@ -383,6 +383,7 @@ sub get_file {
       or die qq{[ERROR]: Unable to open $input->{file}: $!};
     chomp( @{ $input->{data} } = <$CF> );
     close $CF;
+    $input->{success} = 1;
   }
   return $input;
 }


### PR DESCRIPTION
get_file currently does not set the `success` key on `$input`. Because of that, processing files always fails. This patch fixes that by setting the `success` key.